### PR TITLE
Add support to expand path in --setup

### DIFF
--- a/h
+++ b/h
@@ -23,12 +23,15 @@ term = ARGV.shift
 path = nil
 url  = nil
 
+
 case term
 when "--setup"
   code_root = Pathname.new(ARGV[0] || DEFAULT_CODE_ROOT).expand_path
+  argv0 = Pathname.new(Process.argv0)
+  invoked_path = argv0.absolute? ? argv0.to_s : File.expand_path(argv0.to_s, ENV["PWD"] || Dir.pwd)
   puts <<-SH
 h() {
-  _h_dir=$(command h --resolve "#{code_root}" "$@")
+  _h_dir=$(command #{invoked_path} --resolve "#{code_root}" "$@")
   _h_ret=$?
   [ "$_h_dir" != "$PWD" ] && cd "$_h_dir"
   return $_h_ret


### PR DESCRIPTION
This adds support to expand the path of h without it needing to be on your PATH.

Workflow:
1. Git clone the directory
2. Call the setup with the path `eval "$(~/code/github.com/zimbatm/h/h --setup ~/code)"`

I added support to even expand the path if it's relative. What is nice about this is I don't have to include it in my PATH

**Examples**

```
❯ /home/fmzakari/code/github.com/zimbatm/h/h --setup
h() {
  _h_dir=$(command /home/fmzakari/code/github.com/zimbatm/h/h --resolve "/home/fmzakari/src" "$@")
  _h_ret=$?
  [ "$_h_dir" != "$PWD" ] && cd "$_h_dir"
  return $_h_ret
}
```

```
h on  fzakaria/expand-path 
❯ ./h --setup
h() {
  _h_dir=$(command /home/fmzakari/code/github.com/zimbatm/h/h --resolve "/home/fmzakari/src" "$@")
  _h_ret=$?
  [ "$_h_dir" != "$PWD" ] && cd "$_h_dir"
  return $_h_ret
}
```